### PR TITLE
Reduce logging level when globals are not set.

### DIFF
--- a/src/main/java/com/levigo/jbig2/JBIG2Globals.java
+++ b/src/main/java/com/levigo/jbig2/JBIG2Globals.java
@@ -48,7 +48,7 @@ public class JBIG2Globals {
   protected SegmentHeader getSegment(int segmentNr) {
     if (globalSegments.size() == 0) {
       if (log.isErrorEnabled()) {
-        log.error("No global segment added so far.");
+        log.error("No global segment added so far. Use JBIG2ImageReader.setGlobals().");
       }
     }
 

--- a/src/main/java/com/levigo/jbig2/JBIG2ImageReader.java
+++ b/src/main/java/com/levigo/jbig2/JBIG2ImageReader.java
@@ -299,7 +299,7 @@ public class JBIG2ImageReader extends ImageReader {
       }
 
       if (this.globals == null) {
-        log.info("Globals not set.");
+        log.debug("Globals not set.");
       }
 
       this.document = new JBIG2Document((ImageInputStream) this.input, this.globals);


### PR DESCRIPTION
jbig2-imageio currently logs a message at level info when globals are not set. The issue with this is that it's not necessarily an issue not to set them, in particular if they are passed as part of the image stream, but the info level is printed by default, leading to undesirable noise. When the globals are actually missing there will be another log entry: "SEVERE: No global segment added so far.". Therefore this pull request reduces the log level for this message.
