### PR TITLE
Use general service loading instead of Image I/O-specific

### DIFF
--- a/src/main/java/com/levigo/jbig2/util/ServiceLookup.java
+++ b/src/main/java/com/levigo/jbig2/util/ServiceLookup.java
@@ -18,8 +18,7 @@
 package com.levigo.jbig2.util;
 
 import java.util.Iterator;
-
-import javax.imageio.spi.ServiceRegistry;
+import java.util.ServiceLoader;
 
 public class ServiceLookup<B> {
 
@@ -28,14 +27,14 @@ public class ServiceLookup<B> {
   }
 
   public Iterator<B> getServices(Class<B> cls, ClassLoader clsLoader) {
-    Iterator<B> services = ServiceRegistry.lookupProviders(cls);
+    Iterator<B> services = ServiceLoader.load(cls).iterator();
 
     if (!services.hasNext()) {
-      services = ServiceRegistry.lookupProviders(cls, cls.getClass().getClassLoader());
+      services = ServiceLoader.load(cls, cls.getClass().getClassLoader()).iterator();
     }
 
     if (!services.hasNext() && clsLoader != null) {
-      services = ServiceRegistry.lookupProviders(cls, clsLoader);
+      services = ServiceLoader.load(cls, clsLoader).iterator();
     }
 
     return services;


### PR DESCRIPTION
In Java 9, `javax.imageio.spi.ServiceRegistry` checks if the requested service is an implementation of the Image I/O service provider interface. This module used the Image I/O service registry for loading external utility services like logging and caching. This is not an intended use and is now prohibited by the Java 9 runtime. `javax.imageio.spi.ServiceRegistry` uses 'java.util.ServiceLoader' internally.

The lookups done by `javax.imageio.spi.ServiceRegistry` are replaced by that of 'java.util.ServiceLoader'. This fixes issue #10.