### PR TITLE
Huffman user tables in text regions

### DIFF
--- a/src/main/java/com/levigo/jbig2/segments/TextRegion.java
+++ b/src/main/java/com/levigo/jbig2/segments/TextRegion.java
@@ -821,10 +821,20 @@ public class TextRegion implements Region {
     amountOfSymbols = symbols.size();
   }
 
-  private HuffmanTable getUserTable(int referToTable) throws InvalidHeaderValueException, IOException {
-    final SegmentHeader s = segmentHeader.getRtSegments()[referToTable];
-    final Table t = (Table) s.getSegmentData();
-    return new EncodedTable(t);
+  private HuffmanTable getUserTable(final int tablePosition) throws InvalidHeaderValueException, IOException {
+    int tableCounter = 0;
+
+    for (final SegmentHeader referredToSegmentHeader : segmentHeader.getRtSegments()) {
+      if (referredToSegmentHeader.getSegmentType() == 53) {
+        if (tableCounter == tablePosition) {
+          final Table t = (Table) referredToSegmentHeader.getSegmentData();
+          return new EncodedTable(t);
+        } else {
+          tableCounter++;
+        }
+      }
+    }
+    return null;
   }
 
   private void symbolIDCodeLengths() throws IOException {


### PR DESCRIPTION
Fixes issue #26. 
Huffman user tables do not work in TextRegion segments. This issue can be fixed by replacing the method TextRegion.getUserTable() with the method copied from SymbolDictionary.getUserTable(). It implements properly the search algorithm that finds the user table (Table segment) in the referred-to array.