### PR TITLE
Lower range lines in standard Huffman tables

### DIFF
--- a/src/main/java/com/levigo/jbig2/decoder/huffman/StandardTables.java
+++ b/src/main/java/com/levigo/jbig2/decoder/huffman/StandardTables.java
@@ -69,7 +69,7 @@ public class StandardTables {
 					{ 3, 0, 2 }, //
 					{ 4, 3, 3 }, //
 					{ 5, 6, 11 }, //
-					{ 8, 32, Integer.MIN_VALUE, 999 }, /* low */
+					{ 8, 32, -257, 999 }, /* low */
 					{ 7, 32, 75 }, /* high */
 					{ 6, -1, 0 } /* OOB */
 			},
@@ -88,7 +88,7 @@ public class StandardTables {
 					{ 3, 0, 3 }, //
 					{ 4, 3, 4 }, //
 					{ 5, 6, 12 }, //
-					{ 7, 32, Integer.MIN_VALUE, 999 }, /* low */
+					{ 7, 32, -256, 999 }, /* low */
 					{ 6, 32, 76 } /* high */
 			},
 			// B6
@@ -104,7 +104,7 @@ public class StandardTables {
 					{ 3, 8, 256 }, //
 					{ 4, 9, 512 }, //
 					{ 4, 10, 1024 }, //
-					{ 6, 32, Integer.MIN_VALUE, 999 }, /* low */
+					{ 6, 32, -2049, 999 }, /* low */
 					{ 6, 32, 2048 } /* high */
 			},
 			// B7
@@ -121,7 +121,7 @@ public class StandardTables {
 					{ 3, 8, 256 }, //
 					{ 3, 9, 512 }, //
 					{ 3, 10, 1024 }, //
-					{ 5, 32, Integer.MIN_VALUE, 999 }, /* low */
+					{ 5, 32, -1025, 999 }, /* low */
 					{ 5, 32, 2048 } /* high */
 			},
 			// B8
@@ -143,7 +143,7 @@ public class StandardTables {
 					{ 6, 7, 262 }, //
 					{ 7, 8, 390 }, //
 					{ 6, 10, 646 }, //
-					{ 9, 32, Integer.MIN_VALUE, 999 }, /* low */
+					{ 9, 32, -16, 999 }, /* low */
 					{ 9, 32, 1670 }, /* high */
 					{ 2, -1, 0 } /* OOB */
 			},
@@ -167,7 +167,7 @@ public class StandardTables {
 					{ 6, 8, 523 }, //
 					{ 7, 9, 779 }, //
 					{ 6, 11, 1291 }, //
-					{ 9, 32, Integer.MIN_VALUE, 999 }, /* low */
+					{ 9, 32, -32, 999 }, /* low */
 					{ 9, 32, 3339 }, /* high */
 					{ 2, -1, 0 } /* OOB */
 			},
@@ -190,7 +190,7 @@ public class StandardTables {
 					{ 6, 9, 582 }, //
 					{ 6, 10, 1094 }, //
 					{ 7, 11, 2118 }, //
-					{ 8, 32, Integer.MIN_VALUE, 999 }, /* low */
+					{ 8, 32, -22, 999 }, /* low */
 					{ 8, 32, 4166 }, /* high */
 					{ 2, -1, 0 } /* OOB */
 			},
@@ -258,7 +258,7 @@ public class StandardTables {
 					{ 5, 1, 3 }, //
 					{ 6, 2, 5 }, //
 					{ 7, 4, 9 }, //
-					{ 7, 32, Integer.MIN_VALUE, 999 }, /* low */
+					{ 7, 32, -25, 999 }, /* low */
 					{ 7, 32, 25 } /* high */
 			} };
 


### PR DESCRIPTION
Fixes #27.
There is a problem in lower range lines of standard Huffman tables. The JBIG2 standard lists the predefined tables in Annex B. For example, table B.3 specifies the range of values `-infinity...-257` (VAL column) for the lower range line of this table. In StandardTables.java, the value `Integer.MIN_VALUE` has been used as the `rangeLow` (to represent `-infinity`). This is incorrect. Instead, the value -257 should be used as `rangeLow`. Lower range lines are special, so the upper end of the VAL range is used as `rangeLow`.

This problem appears 8 times in StandardTables.java because there are 8 lower range lines in total.